### PR TITLE
Fixed Prototype pollution in simple-deep-assign

### DIFF
--- a/simpleDeepAssign.js
+++ b/simpleDeepAssign.js
@@ -35,6 +35,9 @@ function isObject(item/*: any*/)/*: boolean*/ {
  */
 function deepAssignObject(target/*: Object*/, source/*: Object*/)/*: void*/ {
   Object.keys(source).forEach(key => {
+    if (key === '__proto__' || key === 'prototype' || key === 'constructor'){
+      return;
+    }
     if (isObject(target[key]) && isObject(source[key])) {
       deepAssignObject(target[key], source[key]);
       return;


### PR DESCRIPTION
### 📊 Metadata *
Fixed Prototype pollution in ```simple-deep-assign```.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-simple-deep-assign

### ⚙️ Description *
```simple-deep-assign``` is vulnerable to ```Prototype Pollution```.

### 💻 Technical Description *
The package is vulnerable to Prototype pollution in the ```deepAssgin``` function. This vulnerability is fixed by filtering the keywords that causes pollution from the object.

### 🐛 Proof of Concept (PoC) *
```javascript
// poc.mjs
import deepAssign from 'simple-deep-assign';

console.log('Before: ', {}.polluted})
deepAssign({}, JSON.parse('{"__proto__": {"polluted": "Prototype Polluted"}}'));
console.log('After: ', {}.polluted})
```
```
Before: undefined
After: Prototype Polluted
```
![Screenshot 2021-01-10 155540](https://user-images.githubusercontent.com/29670330/104120467-29021b80-535d-11eb-9a68-c3b838d2be12.png)


### 🔥 Proof of Fix (PoF) *
After fix:
![Screenshot 2021-01-10 155751](https://user-images.githubusercontent.com/29670330/104120471-315a5680-535d-11eb-9bb6-b38075cf0bf0.png)


### 👍 User Acceptance Testing (UAT)
All ok.

### 🔗 Relates to...

_Provide the URL of the PR for the disclosure that this fix relates to._
