### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/simpleDeepAssign.js
+++ b/simpleDeepAssign.js
@@ -35,7 +35,7 @@ function isObject(item/*: any*/)/*: boolean*/ {
  */
 function deepAssignObject(target/*: Object*/, source/*: Object*/)/*: void*/ {
   Object.keys(source).forEach(key => {
-    if (isObject(target[key]) && isObject(source[key])) {
+    if (isObject(target[key]) && isObject(source[key]) && !isPrototypePolluted(key)) {
       deepAssignObject(target[key], source[key]);
       return;
     }
@@ -55,6 +55,15 @@ function deepAssignObject(target/*: Object*/, source/*: Object*/)/*: void*/ {
 function deepAssign(target/*: any*/, source/*: any*/)/*: void*/ {
   if (!isObject(target) || !isObject(source)) return;
   deepAssignObject(target, source);
+}
+
+/**
+ * Blacklist certain keys to prevent Prototype Pollution
+ * @param {string} key
+ * @returns {boolean}
+ */
+function isPrototypePolluted(key/*: any*/)/*: boolean*/ {
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 module.exports = {

--- a/simpleDeepAssign.js
+++ b/simpleDeepAssign.js
@@ -59,8 +59,8 @@ function deepAssign(target/*: any*/, source/*: any*/)/*: void*/ {
 
 /**
  * Blacklist certain keys to prevent Prototype Pollution
- * @param {string} key
- * @returns {boolean}
+ * @private
+ * @param {string} key - object key
  */
 function isPrototypePolluted(key/*: any*/)/*: boolean*/ {
   return ['__proto__', 'constructor', 'prototype'].includes(key);

--- a/simpleDeepAssign.test.js
+++ b/simpleDeepAssign.test.js
@@ -146,4 +146,9 @@ test('deepAssignObject', t => {
     d: [ 0, 1, 2 ],
     e: { fn },
   });
+
+  target = {}
+  deepAssignObject(target, JSON.parse('{"__proto__": {"polluted": true}}'));
+  t.deepEqual(target, {});
+  t.is({}.polluted, undefined);
 });


### PR DESCRIPTION
### :bar_chart: Metadata *

`simple-deep-assign` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-simple-deep-assign

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.mjs
import deepAssign from 'simple-deep-assign';

console.log('Before: ', {}.polluted})
deepAssign({}, JSON.parse('{"__proto__": {"polluted": "Prototype Polluted"}}'));
console.log('After: ', {}.polluted})
```
2. Execute the following commands in terminal:
```bash
npm i simple-deep-assign # Install vulnerable module
node poc.mjs #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Prototype Polluted
```

### :fire: Proof of Fix (PoF) *

*I've also added unit test to check Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105133396-b4746d00-5b12-11eb-9b17-9f9cd0ef6c5a.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
